### PR TITLE
README touchups for 15, 16, 18

### DIFF
--- a/Ch15/README.md
+++ b/Ch15/README.md
@@ -5,23 +5,13 @@
 This directory contains multiple examples showing various functional
 programming concepts.
 
-This entire directory can be loaded in an IDE at the `Ch15` level. Java 11+ is
-required.
+This directory can be loaded in an IDE at the `Ch15` level which is recommended
+as a few examples require dependencies. Java 11+ is required.
 
 * `ch15/Ch15Examples.java` - Basic examples from the text
 * `ch15/ClosureExamples.java` - Basic examples of closing over a value
 * `ch15/DepositMain.java` - Example of reflective access to classes
 * `ch15/PrefixerMain.java` - Example of a functional string prefixer
 * `ch15/StreamExamples.java` - Example of using function chaining on streams
-* `ch15/TailRecASM.java` - TODO: Fix or delete
+* `ch15/TailRecASM.java` - Example rewriting a tail recursive function in bytecode
 * `ch15/TailRecNaive.java` - Example of tail recursive function which still fails
-
-Alternatively, the samples may be compiled and run at the command-line as
-follows:
-
-```
-cd Ch15/ch15
-javac *.java
-java -cp .. ch15.Ch15Examples
-```
-

--- a/Ch16/README.md
+++ b/Ch16/README.md
@@ -1,23 +1,30 @@
 # Chapter 16 - Advanced concurrent programming
 
-## `Ch16/ch16`
+## `Ch16/src/ch16`
 
 This directory contains examples of various concurrent programming concepts.
 
 You can load at the `Ch16` directory in an IDE to run these examples. Java 11+
 is required.
 
-* `ch16/SorterMain.java` - Demonstrating parallel sorting on the `ForkJoinPool`
-* `ch16/CFExamples.java` - CompletableFuture examples
+* `src/ch16/SorterMain.java` - Demonstrating parallel sorting on the `ForkJoinPool`
+* `src/ch16/CFExamples.java` - CompletableFuture examples
 
 Alternatively, the samples may be compiled and run at the command-line as
 follows:
 
 ```
-cd Ch16/ch16
+cd Ch16/src/ch16
 javac *.java
 java -cp .. ch16.SorterMain
 ```
+
+## `Ch16/src/ch16/clj`
+
+This directory contains examples involving Clojure persistent types.
+
+* `src/ch16/clj/PersistentExamples.java` - Examples using Clojure persistent types from Java
+* `src/ch16/clj/PersistentVector.java` - Example implementation of Clojure `PersistentVector`
 
 ## `Ch16/coroutine-app`
 

--- a/Ch18/README.md
+++ b/Ch18/README.md
@@ -1,0 +1,22 @@
+# Chapter 18 - Future Java
+
+## `Ch18/ch18`
+
+This directory contains multiple examples. It may be loaded in IDE at the
+`Ch18` level. Java 18+ is required.
+
+* `ch18/AmberExamples.java` - Demonstrating further pattern matching from Project Amber
+* `ch18/Java17Examples.java` - Demonstrating various new features of Java 17
+* `ch18/SwitchExamples.java` - Switch expression examples
+* `ch18/PanamaExamples.java` - Demonstrating interacting with a native library (`libspng`)
+* `org/libspng` - Panama generated wrappers for native library `libspng`
+
+Alternatively, the samples may be compiled and run at the command-line as
+follows:
+
+```
+cd Ch18/ch18
+javac *.java
+java -cp .. ch18.SwitchExamples
+```
+


### PR DESCRIPTION
Updates things for the style we'd done elsewhere on the changes to 15 and 16.

Adds README for 18. I still can't get `Ch18/ch18/AmberExamples.java` to compile, even when I'm on 18 with all the previews enabled. Any hints @kittylyst ?