### PR TITLE
Remove redundant java plugins throughout

### DIFF
--- a/Ch11/gradle-ee-11/build.gradle.kts
+++ b/Ch11/gradle-ee-11/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   application
-  java
 }
 
 application {

--- a/Ch11/gradle-ee-8/build.gradle.kts
+++ b/Ch11/gradle-ee-8/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   application
-  java
 }
 
 application {

--- a/Ch11/gradle-example/build.gradle.kts
+++ b/Ch11/gradle-example/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   application
-  java
   id("org.jetbrains.kotlin.jvm") version "1.4.31"
   id("com.github.spotbugs") version "4.3.0"
 }

--- a/Ch11/gradle-modules/mod-app/build.gradle.kts
+++ b/Ch11/gradle-modules/mod-app/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-  java
   application
 }
 

--- a/Ch11/gradle-modules/non-app/build.gradle.kts
+++ b/Ch11/gradle-modules/non-app/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-  java
   application
 }
 


### PR DESCRIPTION
Was pointed out in review, anywhere we're using `application` doing `java` separately is redundant. 🔪 