### PR TITLE
Fix instructions to run build in Docker

### DIFF
--- a/Ch12/docker-gradle-multi/README.md
+++ b/Ch12/docker-gradle-multi/README.md
@@ -1,9 +1,8 @@
 ## Building
 
-To build the images follow these steps:
+To build the image follow these steps:
 
 ```
-./gradlew installDist
 docker build -t docker-gradle .
 ```
 


### PR DESCRIPTION
This was the entire point of this example, so running Gradle outside is both unneeded and counter to the idea.