### PR TITLE
Fixed error: Invalid filename: ./wgjd/sitecheck/*/*.java

### DIFF
--- a/Ch02/README.md
+++ b/Ch02/README.md
@@ -80,7 +80,8 @@ cd Ch02
 # Compile the example
 javac -d out wgjd.sitecheck/module-info.java \
   wgjd.sitecheck/wgjd/sitecheck/*.java \
-  wgjd.sitecheck/wgjd/sitecheck/*/*.java
+  wgjd.sitecheck/wgjd/sitecheck/concurrent/*.java \
+  wgjd.sitecheck/wgjd/sitecheck/internal/*.java
 
 # Run the example
 java -cp out wgjd.sitecheck.SiteCheck http://github.com/well-grounded-java


### PR DESCRIPTION
Fix for the following error:
Ch02> javac -d out "wgjd.sitecheck/module-info.java" "wgjd.sitecheck/wgjd/sitecheck/*.java" "wgjd.sitecheck
/wgjd/sitecheck/*/*.java" 
error: Invalid filename: wgjd.sitecheck/wgjd/sitecheck/*/*.java
Usage: javac <options> <source files>
use --help for a list of possible options
